### PR TITLE
allow lookup when there is already a popup

### DIFF
--- a/js/hoverdict.js
+++ b/js/hoverdict.js
@@ -258,7 +258,10 @@ function lookupWord(word, initialPosition) {
 
 function documentKeyDown(event) {
 	pressedKeys[event.keyCode] = true;
-	if(popup == null && pressedKeys[16] && pressedKeys[17]) {
+	if(pressedKeys[16] && pressedKeys[17]) {
+		// close existing popup
+		closePopup();
+
 		// Get selected text
 		var word = getSelectionText();
 		
@@ -285,9 +288,9 @@ function documentKeyUp(event) {
 	pressedKeys[event.keyCode] = false;
 }
 
-function documentMouseDown(event) {
+function closePopup() {
 	if(popup != null && !popup[0].contains(event.target)) {
-		popup.stop(true, true).fadeOut(100,
+		popup.stop(true, true).fadeOut(0,
 			function() {
 				// When animation is done, remove the popup
 				popup.remove();
@@ -295,6 +298,10 @@ function documentMouseDown(event) {
 			}
 		);
 	}
+}
+
+function documentMouseDown(event) {
+	closePopup();
 }
 
 $(document).mousemove(documentMouseMove).keydown(documentKeyDown).keyup(documentKeyUp).mousedown(documentMouseDown);

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Hover Lookup",
-	"version": "1.1",
+	"version": "1.1.1",
 	"description": "Holding <CTRL> + <SHIFT> while hovering over a word will show the wiktionary entry for that word in an inline window.",
 	"manifest_version": 2,
 	"permissions": [


### PR DESCRIPTION
No longer need to first click to close popup before looking up another word. Tested locally on browser thru [https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae](url).